### PR TITLE
Add docs link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ npm run docs       # run doc generation on js files
 
 ## Documentation
 
-### [Website](https://cse110-fa22-group23.github.io/cse110-fa22-group23/source/out/index.html)
+### [Website](https://cse110-fa22-group23.github.io/cse110-fa22-group23/)
+
+### [Docs](https://cse110-fa22-group23.github.io/cse110-fa22-group23/out/)
 
 ### [Contribution Guidelines](docs/CONTRIBUTING.md)
 


### PR DESCRIPTION
The github pages url changed, so I am just fixing the links in the readme.